### PR TITLE
Fix Dockerfile dependency copy path to include Python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # ---- runtime
 FROM base AS runtime
+ARG PY_VERSION
 # copy installed deps from deps stage
-COPY --from=deps /usr/local/lib/python*/site-packages /usr/local/lib/python*/site-packages
+COPY --from=deps /usr/local/lib/python${PY_VERSION}/site-packages /usr/local/lib/python${PY_VERSION}/site-packages
 COPY --from=deps /usr/local/bin /usr/local/bin
 
 # app code LAST → tiny rebuild on change


### PR DESCRIPTION
## Summary
- copy python packages from deps stage into correct python version directory
- reuse build ARG for PY_VERSION in runtime stage

## Testing
- `python -m py_compile bot.py`
- `docker build -t telegram-bot-test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1688f01b0832d946064ca56b707f6